### PR TITLE
Grapher customization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,12 @@ lkmltools/linter/rules/otherrules/__pycache__/
 lkmltools/updater/__pycache__/
 test/__pycache__/
 
+build/
+dist/
+lookml_tools.egg-info/
+
 .DS_Store
 .cache/
 graph.png
+config.json
+

--- a/lkmltools/grapher/lookml_grapher.py
+++ b/lkmltools/grapher/lookml_grapher.py
@@ -165,18 +165,20 @@ class LookMlGrapher():
             for parent in e['extends']:
                 self.explores_to_explores.append((parent, explore_name))
         # this is the first view mentioned
-        key = 'from'
-        if key not in e:
-            # if there is no from parameter, the name of the explore will be taken as a view name
-            key = 'name'              
-        self.explores_to_views.append((explore_name, e[key]))
+        if 'from' in e:
+                self.explores_to_views.append((explore_name, e['from'] + '*'))
+        elif 'view_name' in e:
+            self.explores_to_views.append((explore_name, e['view_name'] + '*'))
+        elif 'extends' not in e:
+            # if there is no from/view_name parameter and no inheritance defined, explore name will be taken as a view name
+            self.explores_to_views.append((explore_name, e['name'] + '*'))
         # but there could be more mentioned in the list (if any) of joins
         if 'joins' in e:
             for k in e['joins']:
                 key = 'from'
                 if key not in k:
                     key = 'name'
-                self.explores_to_views.append((explore_name, k[key]))
+                self.explores_to_views.append((explore_name, k[key] + '*'))
 
     def process_views(self, v):
         '''extract the views referenced by these views and
@@ -189,12 +191,12 @@ class LookMlGrapher():
             nothing. Side effect is to add to maps
 
         '''
-        view_name = v['name']
+        view_name = v['name'] + '*'
         self.node_map[view_name] = NodeType.VIEW
         if 'extends' in v:
             # add relationships to the views that are being extended (inherited)
             for parent in v['extends']:
-                self.views_to_views.append((parent, view_name)) 
+                self.views_to_views.append((parent + '*', view_name)) 
 
     def process_lookml(self, lookml):
         '''given a filepath to a LookML file, extract the views, models, explores as the nodes

--- a/lkmltools/grapher/lookml_grapher.py
+++ b/lkmltools/grapher/lookml_grapher.py
@@ -39,7 +39,7 @@ class LookMlGrapher():
 
         # list of edge pair names
         self.models_to_explores = []
-        self.explores_to_views = []
+        self.views_to_explores = []
         self.explores_to_explores = []
         self.views_to_views = []
 
@@ -111,11 +111,17 @@ class LookMlGrapher():
             nothing but side effect is that any orphans are tagged in the node map
 
         '''
-        referenced_views = set([v[1] for v in self.explores_to_views])
+        referenced_views = set([v[0] for v in self.views_to_explores])
         view_names = set([k for k in self.node_map if self.node_map[k] == NodeType.VIEW])
         orphans = view_names - referenced_views
-        for orphan in orphans:
-            self.node_map[orphan] = NodeType.ORPHAN
+        for view in orphans:
+            explored = False
+            children = self.get_connected_subgraph([view])
+            for child in children:
+                if self.node_map[child] == NodeType.EXPLORE:
+                    explored = True
+            if not explored:
+                self.node_map[view] = NodeType.ORPHAN
 
     def orphans(self):
         '''retrieve the set or orphaned views (if any) from the set of files
@@ -139,10 +145,17 @@ class LookMlGrapher():
         g = nx.DiGraph()
         [g.add_node(node_name) for node_name in self.node_map]
         [g.add_edge(p[0], p[1],weight=4) for p in self.models_to_explores]
-        [g.add_edge(p[0], p[1],weight=4) for p in self.explores_to_views]
+        [g.add_edge(p[0], p[1],weight=4) for p in self.views_to_explores]
         [g.add_edge(p[0], p[1],weight=8) for p in self.explores_to_explores]
         [g.add_edge(p[0], p[1],weight=8) for p in self.views_to_views]
+        # return a connected subgraph (lineage) if the 'root' nodes were provided
+        if 'roots' in self.config:
+            nodes = self.get_connected_subgraph(self.config['roots'])
+            subg = g.subgraph(nodes)
+            return subg
+        # return a full graph with lineage for the project
         return g
+
 
     def process_explores(self, m, e):
         '''extract the views referenced by these explores and
@@ -156,29 +169,29 @@ class LookMlGrapher():
             nothing. Side effect is to add to maps
 
         '''
-        explore_name = e['name'] #['_explore']
+        explore_name = e['name']+'.explore'
         self.node_map[explore_name] = NodeType.EXPLORE
         if m:
-            self.models_to_explores.append((m, explore_name))
+            self.models_to_explores.append((explore_name, m))
         if 'extends' in e:
             # add relationships to the explores that are being extended (inherited)
             for parent in e['extends']:
-                self.explores_to_explores.append((parent, explore_name))
+                self.explores_to_explores.append((parent+'.explore', explore_name))
         # this is the first view mentioned
         if 'from' in e:
-                self.explores_to_views.append((explore_name, e['from'] + '*'))
+                self.views_to_explores.append((e['from']+'.view', explore_name))
         elif 'view_name' in e:
-            self.explores_to_views.append((explore_name, e['view_name'] + '*'))
+            self.views_to_explores.append((e['view_name']+'.view', explore_name))
         elif 'extends' not in e:
             # if there is no from/view_name parameter and no inheritance defined, explore name will be taken as a view name
-            self.explores_to_views.append((explore_name, e['name'] + '*'))
+            self.views_to_explores.append((e['name']+'.view', explore_name))
         # but there could be more mentioned in the list (if any) of joins
         if 'joins' in e:
             for k in e['joins']:
                 key = 'from'
                 if key not in k:
                     key = 'name'
-                self.explores_to_views.append((explore_name, k[key] + '*'))
+                self.views_to_explores.append(( k[key] +'.view', explore_name))
 
     def process_views(self, v):
         '''extract the views referenced by these views and
@@ -191,14 +204,14 @@ class LookMlGrapher():
             nothing. Side effect is to add to maps
 
         '''
-        view_name = v['name'] + '*'
+        view_name =v['name']+'.view'
         self.node_map[view_name] = NodeType.VIEW
         if 'extends' in v:
             # add relationships to the views that are being extended (inherited)
             for parent in v['extends']:
-                self.views_to_views.append((parent + '*', view_name)) 
+                self.views_to_views.append((parent +'.view', view_name)) 
 
-    def process_lookml(self, lookml):
+    def process_lookml(self, lookml): 
         '''given a filepath to a LookML file, extract the views, models, explores as the nodes
         as well as any model-->explore and explore-->view edges
 
@@ -214,7 +227,7 @@ class LookMlGrapher():
             for v in lookml.views():
                 self.process_views(v)
         elif lookml.filetype == 'model':
-            m = lookml.base_name
+            m = lookml.base_name+'.model'
             self.node_map[m] = NodeType.MODEL
             for e in lookml.explores():
                 self.process_explores(m, e)
@@ -234,7 +247,7 @@ class LookMlGrapher():
 
             Returns:
                 nothing but side effect is that nodes are strored in self.node_map and self.models_to_explores 
-                and self.explores_to_views are completed
+                and self.views_to_explores are completed
         '''
         for globstring in globstrings:
             if list(glob.glob(globstring)) == []:
@@ -268,3 +281,19 @@ class LookMlGrapher():
         logging.info("Setting the following options: %s" % args)
 
         self.plot_graph(**args)
+
+    def get_connected_subgraph(self, nodes):
+        edges = self.models_to_explores
+        edges.extend(self.views_to_explores)
+        edges.extend(self.explores_to_explores)
+        edges.extend(self.views_to_views)
+        while True:
+            changed = False
+            for (p, c) in edges:
+                if p in nodes:
+                    nodes.append(c)
+                    edges.remove((p, c))
+                    changed = True
+            if not changed:
+                return nodes
+

--- a/lkmltools/lookml.py
+++ b/lkmltools/lookml.py
@@ -9,6 +9,7 @@ import subprocess
 import os
 import json
 import shlex
+import re
 
 import lkml
 class LookML():
@@ -27,17 +28,23 @@ class LookML():
             raise IOError("Filename does not exist: %s" % infilepath)
 
         self.infilepath = infilepath
-        if infilepath.endswith(".model.lkml"):
+        self.base_filename = os.path.basename(infilepath)
+
+        if self.base_filename.endswith(".model.lkml"):
             self.filetype = 'model'
-        elif infilepath.endswith(".view.lkml"):
-            self.filetype = 'view'
-        elif infilepath.endswith(".explore.lkml"):
+        elif self.base_filename.endswith(".explore.lkml"):
             self.filetype = 'explore'
+        elif self.base_filename.startswith("explore_") and self.base_filename.endswith(".lkml"):
+            self.filetype = 'explore'
+        elif self.base_filename.endswith(".view.lkml"):
+            self.filetype = 'view'
+        elif self.base_filename.endswith(".lkml"):
+            # consider everything else as a view
+            self.filetype = 'view'
         else:
             raise Exception("Unsupported filename " + infilepath)
-        self.base_filename = os.path.basename(infilepath)
-        self.base_name = self.base_filename.replace(".model.lkml", "").replace(".explore.lkml", "").replace(".view.lkml", "")        
-
+        
+        self.base_name = re.sub(r'\.\w+\.lkml$', '', self.base_filename)
         with open(infilepath, 'r') as file:
             self.json_data = lkml.load(file)
 


### PR DESCRIPTION
- Support custom .lkml files that include explores  and start with explore_ 
- Support custom extensions of .lkml files, e.g., '.base.lkml'
- Added postfixes to views, explores, models nodes to accommodate case when objects have the same name
- Added option to extract connected subgraph based on root nodes
- Changed the condition to mark orphans to include views inheritance